### PR TITLE
Add support for TSX file icons

### DIFF
--- a/styles/icon-variables.less
+++ b/styles/icon-variables.less
@@ -56,6 +56,7 @@
 @icon-styl: '\e600';
 @icon-swift: "\e623";
 @icon-ts: '\e622';
+@icon-tsx: '\e622';
 @icon-xml: '\e619';
 @icon-yml: '\e617';
 
@@ -107,5 +108,6 @@
 @color-shell: #FFFFFF; // Shell
 @color-swift: #FC953B; // Swift
 @color-ts: #2279bf; // TypeScript
+@color-tsx: #2279bf; // TypeScript TSX
 @color-xml: #F79451; // XML
 @color-yml: #542d8d; // YML

--- a/styles/icons.less
+++ b/styles/icons.less
@@ -412,6 +412,11 @@ tabs-bar tabs-tab .title.icon-markdown[data-name*=".md"], .tab-bar .tab .title.i
 .icon-tree('.ts', 'ts', 20px, 5px, 2px, -6px, -4px);
 .icon-finder('.ts', 'ts', 20px, 5px, 2px, -4px, -4px);
 
+// TypeScript (TSX)
+.icon-tab('.tsx', 'tsx', 20px, 5px, -3px, -3px, -5px);
+.icon-tree('.tsx', 'tsx', 20px, 5px, 2px, -6px, -4px);
+.icon-finder('.tsx', 'tsx', 20px, 5px, 2px, -4px, -4px);
+
 // XML
 .icon-tab('.xml', 'xml', 15px, 2px, 3px, 0px, -2px);
 .icon-tree('.xml', 'xml', 15px, 2px, 2px, -2px, -1px);


### PR DESCRIPTION
Simple fix to allow `.tsx` files to share the TypeScript icon.

fixes: #14 