### PR TITLE
Add override for Geneus

### DIFF
--- a/styles/theme-overrides.less
+++ b/styles/theme-overrides.less
@@ -14,9 +14,10 @@ atom-workspace {
     }
   }
 
-  // Atom Dark/Atom Light
+  // Atom Dark/Atom Light/Geneus
   &.theme-atom-dark-ui,
-  &.theme-atom-light-ui {
+  &.theme-atom-light-ui,
+  &.theme-geneus-ui {
     // Sidebar
     .entries.list-tree {
       .file .icon {


### PR DESCRIPTION
Fixes error missplacement in [Geneus-ui theme](https://atom.io/themes/geneus-ui)

I'm the "creator" of said theme, I have tested and this should fix the issues I found with icon missplacement in the tab bar.

If someone finds another issue you may as well redirect them to the [Geneus repository](https://github.com/Positive07/geneus-ui) so that they can fill an issue over there
