### PR TITLE
Add override for nova-atom-ui

### DIFF
--- a/styles/theme-overrides.less
+++ b/styles/theme-overrides.less
@@ -91,4 +91,22 @@ atom-workspace {
       top: -3px;
     }
   }
+
+  &.theme-nova-atom-ui {
+    // Tab Bar
+    .tab-bar .tab {
+      .title:before {
+        float: none;
+        margin-left: -0;
+        margin-right: 10px !important;
+        position: relative;
+        vertical-align: middle;
+      }
+
+      .title.icon:before {
+        margin-top: 0;
+        vertical-align: middle;
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR adds an override for the [nova-atom-ui](https://github.com/trevordmiller/nova-atom-ui) theme. It fixes the placement of icons in tabs. Care to review the changes and give feedback, and merge it, if not? :smiley:

## Screenshots
### Before

![atom-nova-screenshot-before](https://cloud.githubusercontent.com/assets/2318955/18808968/ccb2c3c8-8270-11e6-988a-e3c04c73dbcb.png)

### After
![atom-nova-screenshot-after](https://cloud.githubusercontent.com/assets/2318955/18808967/c8e5d820-8270-11e6-922a-ddc7dafc8c1a.png)
