### PR TITLE
Add override for One Dark/Light Theme's minimally sized tabs

### DIFF
--- a/styles/theme-overrides.less
+++ b/styles/theme-overrides.less
@@ -139,3 +139,26 @@ atom-workspace {
     }
   }
 }
+
+// One Dark, One Light with minimum tab sizing
+.one-dark-light-theme-minimum-tab-sizing() {
+  .tab-bar .tab .title {
+    &::before {
+      position: static;
+      margin-top: 0;
+      margin-left: 0;
+      display: inline-block;
+      vertical-align: middle;
+    }
+  }
+}
+
+@media (max-width: 1000px) {
+  [theme-one-dark-ui-tabsizing="auto"], [theme-one-light-ui-tabsizing="auto"] {
+    .one-dark-light-theme-minimum-tab-sizing();
+  }
+}
+
+[theme-one-dark-ui-tabsizing="minimum"], [theme-one-light-ui-tabsizing="minimum"] {
+  .one-dark-light-theme-minimum-tab-sizing();
+}


### PR DESCRIPTION
The icons were not appearing in the One Dark/Light Theme with the "tab sizing" config set to "minimum", or to "auto" in a small Atom window.

Removing the absolute positioning with hardcoded `top` is better than just adding a `padding-left` to the tabs, as the One Dark/Light theme also has varying height tabs depending on the "layout mode" config.

A Less mixin is being used as `:extend` would not work in this case—the `[tabsizing="minimum"]` rule must be applied independent of any media query.