### PR TITLE
Fix icons on the preview-pane one-dark theme

### DIFF
--- a/styles/theme-overrides.less
+++ b/styles/theme-overrides.less
@@ -17,6 +17,13 @@ atom-workspace {
         }
       }
     }
+    .preview-pane .path.list-nested-item {
+      .icon-file-media, .icon-file-pdf, .icon-file-binary, .icon-file-text, .icon-book, .icon-file-media {
+        &::before {
+          top: 0;
+        }
+      }
+    }
   }
 
   // Atom Dark, Atom Light


### PR DESCRIPTION
Resolving: https://github.com/wyze/atom-seti-icons/issues/70

I closed this PR since it was incorrect. https://github.com/wyze/atom-seti-icons/pull/71